### PR TITLE
Use aarch32-cpu and aarch32-rt.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,42 @@
 version = 4
 
 [[package]]
+name = "aarch32-cpu"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db6700cf01549520abec199376115e1ceb6fde1d1de30064f0f230be8a0c305"
+dependencies = [
+ "arbitrary-int 2.0.0",
+ "arm-targets",
+ "bitbybit",
+ "critical-section",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "aarch32-rt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2aced8779594762e12f1c8196b29e52a5e7743ffe06602b6dfe80504d4ae12"
+dependencies = [
+ "aarch32-cpu",
+ "aarch32-rt-macros",
+ "arm-targets",
+]
+
+[[package]]
+name = "aarch32-rt-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2c6caee3f48c427d9e1c5c11fe143767dc678e60d16bec1f0db63aeda0e48e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "arbitrary-int"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "arm-targets"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3371884971a96d71d8bd4e781188a7d327d7e5e455d07ef4c352922c66695e9e"
+checksum = "8d29a37f252452446b67d5e50dee82a6ce12781218b915244bb6507c10b72812"
 
 [[package]]
 name = "bitbybit"
@@ -52,45 +88,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
-
-[[package]]
-name = "cortex-ar"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ea2a354642e242870bc43b57a517359b0be6e96d302b2811cd0644c979c54e"
-dependencies = [
- "arbitrary-int 2.0.0",
- "arm-targets",
- "bitbybit",
- "critical-section",
- "num_enum",
- "thiserror",
-]
-
-[[package]]
-name = "cortex-ar-rt-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a508fe4db3e2d0fad6be33d236b5140a8c0e704a9946448526af6e948cf95682"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "cortex-r-rt"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9414160ea8c5568e17c16f565ff98e8964ab6cafdc01f9f0ac4abb2beba315b2"
-dependencies = [
- "arm-targets",
- "cortex-ar",
- "cortex-ar-rt-macros",
-]
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "critical-section"
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -200,13 +200,13 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 name = "s32z2-rust-demo"
 version = "0.1.0"
 dependencies = [
+ "aarch32-cpu",
+ "aarch32-rt",
  "arbitrary-int 2.0.0",
  "arm-dcc",
  "arm-gic",
  "arm-targets",
  "bitbybit",
- "cortex-ar",
- "cortex-r-rt",
  "derive-mmio",
  "panic-dcc",
  "semihosting",
@@ -229,9 +229,9 @@ checksum = "c3e1c7d2b77d80283c750a39c52f1ab4d17234e8f30bca43550f5b2375f41d5f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ arbitrary-int = "2"
 arm-dcc = "0.1"
 arm-gic = "0.7.1"
 bitbybit = "1.4"
-cortex-ar = { version = "0.3", features=["critical-section-single-core"] }
-cortex-r-rt = "0.2"
+aarch32-cpu = { version = "0.1", features=["critical-section-single-core"] }
+aarch32-rt = "0.1"
 derive-mmio = "0.6"
 panic-dcc = "0.1"
 semihosting = { version = "0.1.20", features = ["stdio"] }
 
 [build-dependencies]
-arm-targets = "0.3"
+arm-targets = "0.4"

--- a/src/bin/generic_timer.rs
+++ b/src/bin/generic_timer.rs
@@ -3,8 +3,8 @@
 #![no_std]
 #![no_main]
 
+use aarch32_cpu::generic_timer::{El1PhysicalTimer, El1VirtualTimer, GenericTimer};
 use arm_dcc::dprintln as println;
-use cortex_ar::generic_timer::{El1PhysicalTimer, El1VirtualTimer, GenericTimer};
 
 // pull in our start-up code
 use s32z2_rust_demo as _;
@@ -14,7 +14,7 @@ use s32z2_rust_demo as _;
 /// It is called by the start-up code in `lib.rs`
 #[no_mangle]
 pub fn s32z2_main() {
-    let cntfrq = cortex_ar::register::Cntfrq::read().0;
+    let cntfrq = aarch32_cpu::register::Cntfrq::read().0;
     println!("cntfrq = {:.03} MHz", cntfrq as f32 / 1_000_000.0);
 
     let delay_ticks = cntfrq * 2;

--- a/src/bin/gic.rs
+++ b/src/bin/gic.rs
@@ -3,62 +3,39 @@
 #![no_std]
 #![no_main]
 
-use core::ptr::NonNull;
-
 use arm_dcc::dprintln as println;
 use arm_gic::{
-    gicv3::{GicCpuInterface, GicV3, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
-    IntId, UniqueMmioPointer,
+    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
+    IntId,
 };
-
-// pull in our start-up code
-use s32z2_rust_demo as _;
-
-/// Offset from PERIPHBASE for GIC Distributor
-const GICD_BASE_OFFSET: usize = 0x0000_0000usize;
-
-/// Offset from PERIPHBASE for the first GIC Redistributor
-const GICR_BASE_OFFSET: usize = 0x0010_0000usize;
 
 /// The entry-point to the Rust application.
 ///
 /// It is called by the start-up code in `lib.rs`
 #[no_mangle]
-pub fn s32z2_main() {
-    // Get the GIC address by reading CBAR
-    let periphbase = cortex_ar::register::ImpCbar::read().periphbase();
-    println!("Found PERIPHBASE {:010p}", periphbase);
-    let gicd_base = periphbase.wrapping_byte_add(GICD_BASE_OFFSET);
-    let gicr_base = periphbase.wrapping_byte_add(GICR_BASE_OFFSET);
-
-    // Initialise the GIC.
-    println!(
-        "Creating GIC driver @ {:010p} / {:010p}",
-        gicd_base, gicr_base
-    );
-    let gicd = unsafe { UniqueMmioPointer::new(NonNull::new(gicd_base.cast()).unwrap()) };
-    let gicr_base = NonNull::new(gicr_base.cast()).unwrap();
-    let mut gic: GicV3 = unsafe { GicV3::new(gicd, gicr_base, 1, false) };
-    println!("Calling git.setup(0)");
-    gic.setup(0);
-    GicCpuInterface::set_priority_mask(0x80);
-
+pub fn s32z2_main(mut peripherals: s32z2_rust_demo::Peripherals) {
     // Configure a Software Generated Interrupt for Core 0
     println!("Configure SGI...");
     let sgi_intid = IntId::sgi(3);
-    gic.set_interrupt_priority(sgi_intid, Some(0), 0x31)
+    peripherals
+        .gic
+        .set_interrupt_priority(sgi_intid, Some(0), 0x31)
         .expect("set prio on SGI int");
-    gic.set_group(sgi_intid, Some(0), Group::Group1NS)
+    peripherals
+        .gic
+        .set_group(sgi_intid, Some(0), Group::Group1NS)
         .expect("set group on SGI int");
 
     println!("gic.enable_interrupt()");
-    gic.enable_interrupt(sgi_intid, Some(0), true)
+    peripherals
+        .gic
+        .enable_interrupt(sgi_intid, Some(0), true)
         .expect("enabling SGI Int");
 
     println!("Enabling interrupts...");
     dump_cpsr();
     unsafe {
-        cortex_ar::interrupt::enable();
+        aarch32_cpu::interrupt::enable();
     }
     dump_cpsr();
 
@@ -77,17 +54,17 @@ pub fn s32z2_main() {
     .expect("send SGI");
 
     loop {
-        cortex_ar::asm::nop();
+        aarch32_cpu::asm::nop();
     }
 }
 
 fn dump_cpsr() {
-    let cpsr = cortex_ar::register::Cpsr::read();
+    let cpsr = aarch32_cpu::register::Cpsr::read();
     println!("CPSR: {:?}", cpsr);
 }
 
 /// Called when the Arm core gets an IRQ
-#[cortex_r_rt::irq]
+#[aarch32_rt::irq]
 fn irq_handler() {
     println!("> IRQ");
     while let Some(int_id) = GicCpuInterface::get_and_acknowledge_interrupt(InterruptGroup::Group1)

--- a/src/bin/gic_timer.rs
+++ b/src/bin/gic_timer.rs
@@ -3,23 +3,12 @@
 #![no_std]
 #![no_main]
 
-use core::ptr::NonNull;
-
+use aarch32_cpu::generic_timer::{El1VirtualTimer, GenericTimer};
 use arm_dcc::dprintln as println;
 use arm_gic::{
-    gicv3::{GicCpuInterface, GicV3, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
-    IntId, UniqueMmioPointer,
+    gicv3::{GicCpuInterface, Group, InterruptGroup, SgiTarget, SgiTargetGroup},
+    IntId,
 };
-use cortex_ar::generic_timer::{El1VirtualTimer, GenericTimer};
-
-// pull in our start-up code
-use s32z2_rust_demo as _;
-
-/// Offset from PERIPHBASE for GIC Distributor
-const GICD_BASE_OFFSET: usize = 0x0000_0000usize;
-
-/// Offset from PERIPHBASE for the first GIC Redistributor
-const GICR_BASE_OFFSET: usize = 0x0010_0000usize;
 
 /// The PPI for the virutal timer, according to the Cortex-R52 Reference Manual
 ///
@@ -33,56 +22,96 @@ const SGI_ID: IntId = IntId::sgi(3);
 ///
 /// It is called by the start-up code in `lib.rs`
 #[no_mangle]
-pub fn s32z2_main() {
-    // Get the GIC address by reading CBAR
-    let periphbase = cortex_ar::register::ImpCbar::read().periphbase();
-    println!("Found PERIPHBASE {:010p}", periphbase);
-    let gicd_base = periphbase.wrapping_byte_add(GICD_BASE_OFFSET);
-    let gicr_base = periphbase.wrapping_byte_add(GICR_BASE_OFFSET);
-
-    // Initialise the GIC.
-    println!(
-        "Creating GIC driver @ {:010p} / {:010p}",
-        gicd_base, gicr_base
-    );
-    let gicd = unsafe { UniqueMmioPointer::new(NonNull::new(gicd_base.cast()).unwrap()) };
-    let gicr_base = NonNull::new(gicr_base.cast()).unwrap();
-    let mut gic: GicV3 = unsafe { GicV3::new(gicd, gicr_base, 1, false) };
-    println!("Calling git.setup(0)");
-    gic.setup(0);
-    GicCpuInterface::set_priority_mask(0x80);
-
-    // Configure a Software Generated Interrupt for Core 0
+pub fn s32z2_main(mut peripherals: s32z2_rust_demo::Peripherals) {
     println!("Configure SGI...");
-    gic.set_interrupt_priority(SGI_ID, Some(0), 0x31)
+    // this is higher priority than the timer
+    peripherals
+        .gic
+        .set_interrupt_priority(SGI_ID, Some(0), 0x10)
         .expect("SGI set_interrupt_priority");
-    gic.set_group(SGI_ID, Some(0), Group::Group1NS)
+    peripherals
+        .gic
+        .set_group(SGI_ID, Some(0), Group::Group1NS)
         .expect("SGI set_group");
-    gic.enable_interrupt(SGI_ID, Some(0), true)
+    peripherals
+        .gic
+        .enable_interrupt(SGI_ID, Some(0), true)
         .expect("SGI enable_interrupt");
 
     println!("Configure Timer Interrupt...");
-    gic.set_interrupt_priority(VIRTUAL_TIMER_PPI, Some(0), 0x31)
+    // this is lower priority than the SGI, so they will nest
+    peripherals
+        .gic
+        .set_interrupt_priority(VIRTUAL_TIMER_PPI, Some(0), 0x20)
         .expect("Timer set_interrupt_priority");
-    gic.set_group(VIRTUAL_TIMER_PPI, Some(0), Group::Group1NS)
+    peripherals
+        .gic
+        .set_group(VIRTUAL_TIMER_PPI, Some(0), Group::Group1NS)
         .expect("Timer set_group");
-    gic.enable_interrupt(VIRTUAL_TIMER_PPI, Some(0), true)
+    peripherals
+        .gic
+        .enable_interrupt(VIRTUAL_TIMER_PPI, Some(0), true)
         .expect("Timer enable_interrupt");
 
-    let mut vgt = unsafe { El1VirtualTimer::new() };
-    vgt.enable(true);
-    vgt.interrupt_mask(false);
-    vgt.counter_compare_set(u64::MAX);
+    peripherals.virtual_timer.enable(true);
+    peripherals.virtual_timer.interrupt_mask(false);
+    peripherals.virtual_timer.counter_compare_set(u64::MAX);
 
     println!("Enabling interrupts...");
-    dump_cpsr();
     unsafe {
-        cortex_ar::interrupt::enable();
+        aarch32_cpu::interrupt::enable();
     }
-    dump_cpsr();
 
-    // Send it
-    println!("Send SGI");
+    peripherals
+        .virtual_timer
+        .countdown_set(peripherals.virtual_timer.frequency_hz());
+
+    let mut count: u32 = 0;
+    loop {
+        aarch32_cpu::asm::wfi();
+        println!("Main loop wake up {}", count);
+        count = count.wrapping_add(1);
+    }
+}
+
+/// Called when the Arm core gets an IRQ
+#[aarch32_rt::irq]
+fn irq_handler() {
+    println!("> irq_handler()");
+    while let Some(int_id) = GicCpuInterface::get_and_acknowledge_interrupt(InterruptGroup::Group1)
+    {
+        println!("- Handling {:?}", int_id);
+        // Re-enable interrupts
+        //
+        // NB: Don't do this until after you've talked to the GIC
+        //
+        // Safety: not in a critical section, so safe to enable interrupts
+        unsafe {
+            aarch32_cpu::interrupt::enable();
+        }
+        if int_id == VIRTUAL_TIMER_PPI {
+            handle_timer_irq();
+        } else if int_id == SGI_ID {
+            handle_sgi_irq();
+        }
+        aarch32_cpu::interrupt::disable();
+        println!("- Handled {:?}", int_id);
+        GicCpuInterface::end_interrupt(int_id, InterruptGroup::Group1);
+    }
+    println!("< irq_handler()");
+}
+
+/// Run when the timer IRQ fires
+fn handle_timer_irq() {
+    println!("> handle_timer_irq()");
+
+    println!("--- Resetting timer...");
+
+    // trigger a timer in 1 second
+    let mut vgt = unsafe { El1VirtualTimer::new() };
+    vgt.countdown_set(vgt.countdown().wrapping_add(vgt.frequency_hz()));
+
+    println!("--- Sending SGI...");
     GicCpuInterface::send_sgi(
         SGI_ID,
         SgiTarget::List {
@@ -94,48 +123,13 @@ pub fn s32z2_main() {
         SgiTargetGroup::CurrentGroup1,
     )
     .expect("send sgi");
+    // make sure the SGI happens
+    aarch32_cpu::asm::isb();
 
-    vgt.countdown_set(vgt.frequency_hz());
-
-    let mut count: u32 = 0;
-    loop {
-        cortex_ar::asm::wfi();
-        println!("Main loop wake up {}", count);
-        count = count.wrapping_add(1);
-    }
-}
-
-fn dump_cpsr() {
-    let cpsr = cortex_ar::register::Cpsr::read();
-    println!("CPSR: {:?}", cpsr);
-}
-
-/// Called when the Arm core gets an IRQ
-#[cortex_r_rt::irq]
-fn irq_handler() {
-    println!("> IRQ");
-    while let Some(int_id) = GicCpuInterface::get_and_acknowledge_interrupt(InterruptGroup::Group1)
-    {
-        println!("- IRQ handle {:?}", int_id);
-        if int_id == VIRTUAL_TIMER_PPI {
-            handle_timer_irq();
-        } else if int_id == SGI_ID {
-            handle_sgi_irq();
-        }
-        GicCpuInterface::end_interrupt(int_id, InterruptGroup::Group1);
-    }
-    println!("< IRQ");
-}
-
-/// Run when the timer IRQ fires
-fn handle_timer_irq() {
-    println!("- Timer fired - resetting");
-    // trigger a timer in 1 second
-    let mut vgt = unsafe { El1VirtualTimer::new() };
-    vgt.countdown_set(vgt.countdown().wrapping_add(vgt.frequency_hz()));
+    println!("< handle_timer_irq()");
 }
 
 /// Run when the SGI is fired
 fn handle_sgi_irq() {
-    println!("- SGI fired");
+    println!("- handle_sgi_irq()");
 }

--- a/src/bin/registers.rs
+++ b/src/bin/registers.rs
@@ -17,23 +17,23 @@ extern "C" {
 /// It is called by the start-up code in `lib.rs`
 #[no_mangle]
 pub fn s32z2_main() {
-    println!("{:?}", cortex_ar::register::Midr::read());
-    println!("{:?}", cortex_ar::register::Cpsr::read());
-    println!("{:?}", cortex_ar::register::ImpCbar::read());
-    println!("{:?}", cortex_ar::register::Vbar::read());
+    println!("{:?}", aarch32_cpu::register::Midr::read());
+    println!("{:?}", aarch32_cpu::register::Cpsr::read());
+    println!("{:?}", aarch32_cpu::register::ImpCbar::read());
+    println!("{:?}", aarch32_cpu::register::Vbar::read());
     // This only works in EL2 and start-up put us in EL1
-    // println!("{:?}", cortex_ar::register::Hvbar::read());
+    // println!("{:?}", aarch32_cpu::register::Hvbar::read());
 
     println!("_stack_top: {:010p}", core::ptr::addr_of!(_stack_top));
 
     println!(
         "{:?} before setting C, I and Z",
-        cortex_ar::register::Sctlr::read()
+        aarch32_cpu::register::Sctlr::read()
     );
-    cortex_ar::register::Sctlr::modify(|w| {
+    aarch32_cpu::register::Sctlr::modify(|w| {
         w.set_c(true);
         w.set_i(true);
         w.set_z(true);
     });
-    println!("{:?} after", cortex_ar::register::Sctlr::read());
+    println!("{:?} after", aarch32_cpu::register::Sctlr::read());
 }

--- a/src/bin/svc.rs
+++ b/src/bin/svc.rs
@@ -4,7 +4,7 @@
 #![no_main]
 
 // pull in our start-up code
-use cortex_ar as _;
+use aarch32_cpu as _;
 use s32z2_rust_demo as _;
 
 use arm_dcc::dprintln as println;
@@ -18,17 +18,17 @@ pub fn s32z2_main() {
     let y = x + 1;
     let z = (y as f64) * 1.5;
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
-    cortex_ar::svc!(0xABCDEF);
+    aarch32_cpu::svc!(0xABCDEF);
     println!("x = {}, y = {}, z = {:0.3}", x, y, z);
     panic!("I am an example panic");
 }
 
 /// This is our SVC exception handler
-#[cortex_r_rt::exception(SupervisorCall)]
+#[aarch32_rt::exception(SupervisorCall)]
 fn svc_handler(arg: u32) {
     println!("In SupervisorCall handler, with arg={:#06x}", arg);
     if arg == 0xABCDEF {
         // test nested SVC calls
-        cortex_ar::svc!(0x456789);
+        aarch32_cpu::svc!(0x456789);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,43 +2,83 @@
 
 #![no_std]
 
-// Need this to bring in the start-up function
+use core::ptr::NonNull;
 
-use cortex_r_rt as _;
+use aarch32_cpu::generic_timer::El1VirtualTimer;
+use aarch32_rt as _;
+use arm_dcc::dprintln as println;
+use arm_gic::{
+    gicv3::{GicCpuInterface, GicV3},
+    UniqueMmioPointer,
+};
 use panic_dcc as _;
 
 mod clocks;
 mod mpu;
 
+/// Offset from PERIPHBASE for GIC Distributor
+pub const GICD_BASE_OFFSET: usize = 0x0000_0000usize;
+
+/// Offset from PERIPHBASE for the first GIC Redistributor
+pub const GICR_BASE_OFFSET: usize = 0x0010_0000usize;
+
+pub struct Peripherals {
+    pub gic: GicV3<'static>,
+    pub virtual_timer: El1VirtualTimer,
+}
+
 /// The entry-point to the Rust application.
-#[cortex_r_rt::entry]
+#[aarch32_rt::entry]
 fn kmain() -> ! {
     unsafe extern "Rust" {
-        safe fn s32z2_main();
+        safe fn s32z2_main(peripherals: Peripherals);
     }
     setup_core();
-    s32z2_main();
+
+    // Get the GIC address by reading CBAR
+    let periphbase = aarch32_cpu::register::ImpCbar::read().periphbase();
+    println!("Found PERIPHBASE {:010p}", periphbase);
+    let gicd_base = periphbase.wrapping_byte_add(GICD_BASE_OFFSET);
+    let gicr_base = periphbase.wrapping_byte_add(GICR_BASE_OFFSET);
+
+    // Initialise the GIC.
+    println!(
+        "Creating GIC driver @ {:010p} / {:010p}",
+        gicd_base, gicr_base
+    );
+    let gicd = unsafe { UniqueMmioPointer::new(NonNull::new(gicd_base.cast()).unwrap()) };
+    let gicr_base = NonNull::new(gicr_base.cast()).unwrap();
+    let mut gic: GicV3 = unsafe { GicV3::new(gicd, gicr_base, 1, false) };
+    println!("Calling git.setup(0)");
+    gic.setup(0);
+    GicCpuInterface::set_priority_mask(0x80);
+
+    let peripherals = Peripherals {
+        gic,
+        virtual_timer: unsafe { El1VirtualTimer::new() },
+    };
+    s32z2_main(peripherals);
     semihosting::process::exit(0);
 }
 
 /// Setup RTU0 Core 1
 fn setup_core() {
     // Enable the peripheral port in EL1
-    let mut reg = cortex_ar::register::ImpPeriphpregionr::read();
+    let mut reg = aarch32_cpu::register::ImpPeriphpregionr::read();
     reg.0 |= 1;
     unsafe {
-        cortex_ar::register::ImpPeriphpregionr::write(reg);
+        aarch32_cpu::register::ImpPeriphpregionr::write(reg);
     }
-    cortex_ar::asm::dsb();
-    cortex_ar::asm::isb();
+    aarch32_cpu::asm::dsb();
+    aarch32_cpu::asm::isb();
     // enable branch prediction, icache and dcache
-    cortex_ar::register::Sctlr::modify(|w| {
+    aarch32_cpu::register::Sctlr::modify(|w| {
         w.set_c(true);
         w.set_i(true);
         w.set_z(true);
     });
-    cortex_ar::asm::dsb();
-    cortex_ar::asm::isb();
+    aarch32_cpu::asm::dsb();
+    aarch32_cpu::asm::isb();
     // Need the MPU be able to talk to the clock peripheral
     mpu::enable();
     // Turn on the PLLs

--- a/src/mpu.rs
+++ b/src/mpu.rs
@@ -4,7 +4,7 @@
 //! any peripherals using the default MPU 'background' configuration that
 //! applies when the MPU is disabled.
 
-use cortex_ar::{
+use aarch32_cpu::{
     self as _,
     pmsav8::{
         Cacheable, El1AccessPerms, El1Config, El1Mpu, El1Region, El1Shareability, MemAttr,


### PR DESCRIPTION
Also moves peripheral setup into the library, so we don't duplicate it.