### PR TITLE
Draft: Use unreleased aarch32-rt with SMP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5db6700cf01549520abec199376115e1ceb6fde1d1de30064f0f230be8a0c305"
 dependencies = [
  "arbitrary-int 2.1.1",
- "arm-targets",
+ "arm-targets 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitbybit 1.4.0",
  "num_enum",
  "thiserror",
@@ -17,12 +17,11 @@ dependencies = [
 
 [[package]]
 name = "aarch32-cpu"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a1c6b820a21052085271d8d3ef4bd0379894b525212b45405af905a2aae415"
+version = "0.4.0"
+source = "git+https://github.com/thejpster/aarch32?branch=add-smp-support#a9f8bfd3d7f413bcc182de332064aa2ae5a11911"
 dependencies = [
  "arbitrary-int 2.1.1",
- "arm-targets",
+ "arm-targets 0.4.3 (git+https://github.com/thejpster/aarch32?branch=add-smp-support)",
  "bitbybit 2.0.0",
  "critical-section",
  "num_enum",
@@ -31,24 +30,22 @@ dependencies = [
 
 [[package]]
 name = "aarch32-rt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18cc91c6671e3fb3794678776cf1f47fdd2525618ff933d73e0c66cd405c84da"
+version = "0.4.0"
+source = "git+https://github.com/thejpster/aarch32?branch=add-smp-support#a9f8bfd3d7f413bcc182de332064aa2ae5a11911"
 dependencies = [
- "aarch32-cpu 0.3.0",
+ "aarch32-cpu 0.4.0",
  "aarch32-rt-macros",
- "arm-targets",
+ "arm-targets 0.4.3 (git+https://github.com/thejpster/aarch32?branch=add-smp-support)",
 ]
 
 [[package]]
 name = "aarch32-rt-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d2ce367c2cb97bf988dc9d96f5d702fa40ba15c9369521e1508a6667d2a10"
+version = "0.4.0"
+source = "git+https://github.com/thejpster/aarch32?branch=add-smp-support#a9f8bfd3d7f413bcc182de332064aa2ae5a11911"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -74,9 +71,9 @@ checksum = "993a810118f8f37e9c4411c86f1c4c940a09a7ab34b7bf2d88d06f50c553fab7"
 
 [[package]]
 name = "arm-dcc"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67039ca654718fb8c6acff38661f610c63c9b53e14509c78210be3a1f9e2defe"
+checksum = "8beb7c492a75971ffae0fdaad04bbe10e2f830d2651f01b2220bd1138ab889a4"
 
 [[package]]
 name = "arm-gic"
@@ -92,9 +89,14 @@ dependencies = [
 
 [[package]]
 name = "arm-targets"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570304ff56d67c17f521f68d55a63dffbb067d63f675e2b4603283e2d50b9d59"
+checksum = "c0555f30eb9cd1a07d7677d01971da6c74cbbb0f73f0667cbee74e590a68a619"
+
+[[package]]
+name = "arm-targets"
+version = "0.4.3"
+source = "git+https://github.com/thejpster/aarch32?branch=add-smp-support#a9f8bfd3d7f413bcc182de332064aa2ae5a11911"
 
 [[package]]
 name = "bitbybit"
@@ -105,7 +107,7 @@ dependencies = [
  "arbitrary-int 1.3.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -116,14 +118,14 @@ checksum = "71d2a3353d70ac1091a33cbf31fc7e77b19091538a7e306e3740712af19807ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "byteorder"
@@ -133,9 +135,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -184,7 +186,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -195,14 +197,14 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "derive-mmio"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005a6dabf68a87a460d3cb9b8e2fd5de3f474fc34e8d9451f5a1b6db518da143"
+checksum = "acd34ba795703e849ab4136e8886fa2140935e2e27640d22c7da6ef5796324af"
 dependencies = [
  "derive-mmio-macro",
  "rustversion",
@@ -210,14 +212,13 @@ dependencies = [
 
 [[package]]
 name = "derive-mmio-macro"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584dc8e12e4aeb88000c2be8ef7db15657c817fba3e77999a24807d1efcdeefa"
+checksum = "bb3c030cba3e3eb0fac8a6877210e23e521535f725b72b137d1d5b8b0085c077"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -236,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
 dependencies = [
  "aarch32-cpu 0.1.0",
- "arm-targets",
+ "arm-targets 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cordyceps",
  "critical-section",
  "document-features",
@@ -253,7 +254,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -371,21 +372,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -429,9 +430,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "litrs"
@@ -441,9 +442,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom"
@@ -469,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nb"
@@ -515,7 +516,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -526,9 +527,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "panic-dcc"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bccfba15bcb1698b50f2185ec8c97236f9be068a9627f89e85c78657f2f85b"
+checksum = "0113c2b4e580bd8ffa95fe25cefb1a1f84d5041fb706b88ec293b3535468a2db"
 dependencies = [
  "arm-dcc",
 ]
@@ -540,50 +541,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -592,26 +571,26 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "s32z2-rust-demo"
 version = "0.1.0"
 dependencies = [
- "aarch32-cpu 0.3.0",
+ "aarch32-cpu 0.4.0",
  "aarch32-rt",
  "arbitrary-int 2.1.1",
  "arm-dcc",
  "arm-gic",
- "arm-targets",
+ "arm-targets 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitbybit 1.4.0",
  "critical-section",
  "derive-mmio",
@@ -657,15 +636,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -681,9 +660,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -692,29 +682,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -738,7 +728,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -824,20 +814,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,21 @@ rust-version = "1.86"
 version = "0.1.0"
 
 [dependencies]
-aarch32-cpu = { version = "0.3", features=["critical-section-multi-core"] }
-aarch32-rt = "0.3"
+aarch32-cpu = { git = "https://github.com/thejpster/aarch32", branch = "add-smp-support", features=["critical-section-multi-core"] }
+aarch32-rt = { git = "https://github.com/thejpster/aarch32", branch = "add-smp-support" }
 arbitrary-int = "2"
-arm-dcc = "0.1"
+arm-dcc = "0.2"
 arm-gic = "0.7.1"
 bitbybit = "1.4"
 critical-section = "1.2.0"
-derive-mmio = "0.6"
+derive-mmio = "0.8"
 embassy-executor = { version = "0.10.0", features = ["platform-cortex-ar", "executor-thread"] }
 embassy-futures = "0.1.2"
 embassy-sync = "0.8.0"
 embassy-time = { version = "0.5.1", features = ["tick-hz-8_000_000"] }
 embassy-time-driver = "0.2.2"
 embassy-time-queue-utils = "0.3.2"
-panic-dcc = "0.1"
+panic-dcc = "0.2"
 semihosting = { version = "0.1.20", features = ["stdio"] }
 
 [build-dependencies]

--- a/criticalup.toml
+++ b/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "stable-26.02.0"
+release = "beta-26.05-2026-07-12"
 packages = [
     "cargo-${rustc-host}",
     "clippy-${rustc-host}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 use core::{ptr::NonNull, sync::atomic::AtomicBool};
 
 use aarch32_cpu::generic_timer::El1VirtualTimer;
-#[cfg(target_arch = "arm")]
-use aarch32_cpu::register::{cpsr::ProcessorMode, Cpsr, Hactlr};
 use aarch32_rt as _;
 use arm_dcc::dprintln as println;
 use arm_gic::{
@@ -80,7 +78,7 @@ fn kmain() -> ! {
 
 /// The entry-point to the Rust application on Core 1
 #[unsafe(no_mangle)]
-pub extern "C" fn kmain2() {
+pub extern "C" fn kmain_secondary() {
     unsafe extern "Rust" {
         safe fn s32z2_main2();
     }
@@ -127,92 +125,41 @@ fn setup_core() {
     clocks::configure_pll();
 
     // Wake up second core
-    CORE1_RELEASED.store(true, core::sync::atomic::Ordering::Relaxed);
+    CORE1_RELEASED.store(true, core::sync::atomic::Ordering::Release);
     aarch32_cpu::asm::sev();
 }
 
-// Custom start-up code for S32Z2
-//
-// Supplements the equivalent routine in aarch32-rt, as we need to do extra things:
-//
-// * Erase the memory, so that we don't get ECC errors
-// * Initialise the TCMs
-// * Configure the Frequency register for the Generic Timer to 8 MHz
-// * Set-up Core 1 with its own stacks, and set it running kmain2 at EL1
-#[cfg(target_arch = "arm")]
-core::arch::global_asm!(
-    r#"
-    .section .text.startup
-    .align 0
-
-    .global _start
-    .type _start,%function
-    _start:
-        // Read MPIDR into R0
-        mrc     p15, 0, r0, c0, c0, 5
-        ands    r0, r0, 0xFF
-        beq     core0_init
-    core1_init:
-        // wait for our shared variable to not be zero
-        ldr     r0, ={released_bool}
-        mov     r1, #0
-    core1_spin:
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn _asm_secondary_core_park() {
+    core::arch::naked_asm!(
+        r#"
+        // Some hardware register
+        ldr     r0, ={core1_released}
+    1:
+        // Wait until Core 0 does a 'sev'
         wfe
-        // spin until boolean is set.
-        ldr     r2, [r0]  
-        cmp     r1, r2
-        beq     core1_spin
-    core1_released:
-        // Now we must exit EL2...
-        // Set the HVBAR (for EL2) to _vector_table
-        ldr     r0, =_vector_table
-        mcr     p15, 4, r0, c12, c0, 0
-        // Configure HACTLR to let us enter EL1
-        mrc     p15, 4, r0, c1, c0, 1
-        mov     r1, {hactlr_bits}
-        orr     r0, r0, r1
-        mcr     p15, 4, r0, c1, c0, 1
-        // Program the SPSR - enter system mode (0x1F) in Arm mode with IRQ, FIQ masked
-        mov		r0, {sys_mode}
-        msr		spsr_hyp, r0
-        adr		r0, start_core1_el1
-        msr		elr_hyp, r0
-        dsb
-        isb
-        // leave EL2, 'return' to EL1
-        eret
-    start_core1_el1:
-        // this is where we continue once in EL1, after the eret
-        // Allow VFP coprocessor access
-        mrc     p15, 0, r0, c1, c0, 2
-        orr     r0, r0, #0xF00000
-        mcr     p15, 0, r0, c1, c0, 2
-        // Enable VFP
-        mov     r0, #0x40000000
-        vmsr    fpexc, r0
-        // Set the VBAR (for EL1) to _vector_table.
-        ldr     r0, =_vector_table
-        mcr     p15, 0, r0, c12, c0, 0
-        // set up our stacks - also switches to SYS mode
-        movs    r0, #1
-        bl      _stack_setup_preallocated
-        // Zero all registers before calling kmain2
-        mov     r0, 0
-        mov     r1, 0
-        mov     r2, 0
-        mov     r3, 0
-        mov     r4, 0
-        mov     r5, 0
-        mov     r6, 0
-        mov     r7, 0
-        mov     r8, 0
-        mov     r9, 0
-        mov     r10, 0
-        mov     r11, 0
-        mov     r12, 0
-        // call our kmain2 for core 1
-        bl      kmain2
-    core0_init:
+        // Spin until register is non-zero.
+        lda     r1, [r0]
+        cmp     r1, 0
+        beq     1b
+        // return to start-up
+        bx      lr
+    "#,
+    core1_released = sym CORE1_RELEASED
+    );
+}
+
+#[unsafe(naked)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn _start() {
+    core::arch::naked_asm!(
+        r#"
+        mrc     p15, 0, r0, c0, c0, 5   // Read MPUID
+        ands    r0, r0, 0xFF            // Is this Core 0?
+        beq     1f
+        b       _default_start          // Core 1 can leave right away
+    1:
         // ECC init for S32Z2, which uses a table of (start, len)
 
         // r4 is the address of the current entry in the table.
@@ -308,26 +255,6 @@ core::arch::global_asm!(
         cmp     r1, #0                /* Is the end of DMEM? */
         bne     InitTcmLoop           /* Restart loop if not */
         bx      lr
-    "#,
-    released_bool = sym CORE1_RELEASED,
-    hactlr_bits = const {
-        Hactlr::new_with_raw_value(0)
-            .with_cpuactlr(true)
-            .with_cdbgdci(true)
-            .with_flashifregionr(true)
-            .with_periphpregionr(true)
-            .with_qosr(true)
-            .with_bustimeoutr(true)
-            .with_intmonr(true)
-            .with_err(true)
-            .with_testr1(true)
-            .raw_value()
-    },
-    sys_mode = const {
-        Cpsr::new_with_raw_value(0)
-            .with_mode(ProcessorMode::Sys)
-            .with_i(true)
-            .with_f(true)
-            .raw_value()
-    },
-);
+    "#
+    )
+}


### PR DESCRIPTION
Allows us to delete a whole bunch of code.

Draft until aarch32-rt is released with the changes.